### PR TITLE
Implements workout update functionality

### DIFF
--- a/internal/api/workout_handler.go
+++ b/internal/api/workout_handler.go
@@ -76,3 +76,74 @@ func (wh *WorkoutHandler) HandleCreateWorkout(w http.ResponseWriter, r *http.Req
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(createdWorkout)
 }
+
+func (wh *WorkoutHandler) HandleUpdateWorkoutByID(w http.ResponseWriter, r *http.Request){
+	// Extract "id" from URL
+	paramsWorkoutID := chi.URLParam(r, "id")
+	if paramsWorkoutID == "" {
+		http.NotFound(w, r) // 404 if no ID provided
+		return
+	}
+
+	// Convert string ID to int64
+	workoutId, err := strconv.ParseInt(paramsWorkoutID, 10, 64)
+	if err != nil {
+		fmt.Println("Workout doesn't exist")
+		http.NotFound(w, r) // 404 if invalid ID
+		return
+	}
+
+	existingWorkout, err := wh.workoutStore.GetWorkoutById(workoutId)
+	if err != nil {
+		http.Error(w, "Failed to fetch workout", http.StatusInternalServerError)
+		return
+	}
+	
+	//if workout is not found
+	if existingWorkout == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var updateWorkoutRequest struct {
+		Title           *string              `json:"title"`
+		Description     *string              `json:"description"`
+		DurationMinutes *int                 `json:"duration_minutes"`
+		CaloriesBurned  *int                 `json:"calories_burned"`
+		Entries         []store.WorkoutEntry `json:"entries"`
+	}
+
+	err = json.NewDecoder(r.Body).Decode(&updateWorkoutRequest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	//Since all the items in the struct are pointers and the null value of a pointer is nil. So by using pointers , we can check if the items are empty or not, if not empty , we update the value
+	if updateWorkoutRequest.Title != nil {
+		existingWorkout.Title = *updateWorkoutRequest.Title
+	}
+	if updateWorkoutRequest.Description != nil {
+		existingWorkout.Description = *updateWorkoutRequest.Description
+	}
+	if updateWorkoutRequest.DurationMinutes != nil {
+		existingWorkout.DurationMinutes = *updateWorkoutRequest.DurationMinutes
+	}
+	if updateWorkoutRequest.CaloriesBurned != nil {
+		existingWorkout.CaloriesBurned = *updateWorkoutRequest.CaloriesBurned
+	}
+	if updateWorkoutRequest.Entries != nil {
+		existingWorkout.Entries = updateWorkoutRequest.Entries
+	}
+
+	err = wh.workoutStore.UpdateWorkout(existingWorkout)
+	if err != nil {
+		fmt.Println("Update workout err: " , err)
+		http.Error(w, "Failed to update the workout", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(existingWorkout)
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -14,5 +14,6 @@ func SetupRoutes(app *app.Application) *chi.Mux{
 	r.Get("/workouts/{id}", app.WorkoutHandler.HandleWorkoutByID)
 
 	r.Post("/workouts", app.WorkoutHandler.HandleCreateWorkout)
+	r.Put("/workouts/{id}", app.WorkoutHandler.HandleUpdateWorkoutByID)
 	return r
 }


### PR DESCRIPTION
Adds the ability to update existing workouts via a PUT request.

The handler now includes logic to:
- Extract the workout ID from the URL.
- Retrieve the existing workout from the database.
- Decode the request body into an update request struct.
- Update the existing workout's fields based on the provided data.
- Persist the updated workout to the database, including deleting and re-inserting the workout entries within a transaction.

Error handling has been included, and the response includes appropriate status codes and content type.